### PR TITLE
Fix: Display !important flag in CSS declarations

### DIFF
--- a/src/devtools/client/inspector/rules/components/DeclarationValue.tsx
+++ b/src/devtools/client/inspector/rules/components/DeclarationValue.tsx
@@ -15,8 +15,14 @@ interface DeclarationValueProps {
 
 class DeclarationValue extends React.PureComponent<DeclarationValueProps> {
   render() {
+    // Reproduction step Repro:DeclarationValue:
+    // the React element creation which triggered this render is at reproduction step Repro:MatchedSelector
     return this.props.values.map(v => {
       if (typeof v === "string") {
+        const importantMatch = v.match(/^(.*?)(!important)?$/);
+        if (importantMatch && importantMatch[2]) {
+          return [importantMatch[1], " ", importantMatch[2]];
+        }
         return v;
       }
 


### PR DESCRIPTION
When a CSS declaration includes the !important flag, it should be properly displayed in the UI. This fix ensures that when a string value contains !important, it is properly split and rendered with a space before the !important flag.

Fixes #6